### PR TITLE
Avoid requiring column types from schema def

### DIFF
--- a/src/flattenObject.ts
+++ b/src/flattenObject.ts
@@ -1,0 +1,26 @@
+// Convert objecto to one level of deepness
+const flattenObject = (ob, separator = '.') => {
+  const toReturn = {}
+
+  for (const index in ob) {
+    if (!ob.hasOwnProperty || !Object.prototype.hasOwnProperty.call(ob, index)) {
+      continue
+    }
+
+    if ((typeof ob[index]) === 'object') {
+      const flatObject = flattenObject(ob[index])
+      for (const prop in flatObject) {
+        if (!Object.prototype.hasOwnProperty.call(flatObject, prop)) {
+          continue
+        }
+
+        toReturn[index + separator + prop] = flatObject[prop]
+      }
+    } else {
+      toReturn[index] = ob[index]
+    }
+  }
+  return toReturn
+}
+
+export default flattenObject

--- a/src/queryTables.spec.ts
+++ b/src/queryTables.spec.ts
@@ -46,7 +46,7 @@ test('queryTables', async () => {
     .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(employeeBody))))
     .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify(goalsConfigBody))))
 
-  const sql = 'SELECT employees.id + goal_configs.id as value FROM goal_configs JOIN employees ON (employees.id + ?) == goal_configs.id'
+  const sql = 'SELECT employees.id + goal_configs.id as value FROM goal_configs JOIN employees ON (employees.id + ?) = goal_configs.id + 0'
 
   const result = await queryTables(sql, [5], {})
 
@@ -54,6 +54,7 @@ test('queryTables', async () => {
   expect(mockedFetch).toHaveBeenCalledWith('https://api.example.com/schema', { headers })
   expect(mockedFetch).toHaveBeenCalledWith('https://api.example.com/tables/goal_configs', { headers })
   expect(mockedFetch).toHaveBeenCalledWith('https://api.example.com/tables/employees', { headers })
+
   expect(result).toEqual([{ value: 25 }])
 })
 

--- a/src/queryTables.ts
+++ b/src/queryTables.ts
@@ -16,6 +16,8 @@ type FieldDefinition = {
 type TableDefinition = {
   name: string,
   url: string,
+  result_key: string,
+  data: any,
   fields: Array<FieldDefinition>
 }
 
@@ -82,7 +84,7 @@ async function populateTables (db: DatabaseType, usedTables: Array<string>, head
     if (fixedData.length === 0) return
 
     const dynamicDefinition = {
-      name: tableDefinition.name,
+      ...tableDefinition,
       data: fixedData[0] // We base table definition on first row
     }
 
@@ -108,16 +110,6 @@ function storeToDb (db: DatabaseType, tableDefinition: TableDefinition, data) {
     const normalizedRow = { ...tableDefinition.data, ...row }
     insert.run(normalizedRow)
   }
-}
-
-const TYPES = { // Perdona Pau ;)
-  bigint: 'BIGINT',
-  date: 'DATE',
-  number: 'INTEGER',
-  integer: 'INTEGER',
-  string: 'TEXT',
-  text: 'TEXT',
-  boolean: 'BOOLEAN'
 }
 
 function createTable (db: DatabaseType, tableDefinition: TableDefinition) {

--- a/src/queryTables.ts
+++ b/src/queryTables.ts
@@ -16,7 +16,6 @@ type FieldDefinition = {
 type TableDefinition = {
   name: string,
   url: string,
-  result_key: string,
   data: any,
   fields: Array<FieldDefinition>
 }
@@ -78,8 +77,7 @@ async function populateTables (db: DatabaseType, usedTables: Array<string>, head
   const promises = filteredTableDefinition.map(async (tableDefinition) => {
     const data = await fetchTableData(tableDefinition, headers)
 
-    const resultKey = tableDefinition.result_key
-    const fixedData = resultKey ? data[resultKey].map(field => flattenObject(field, '_')) : data.map(field => flattenObject(field, '_'))
+    const fixedData = data.map(field => flattenObject(field, '_'))
 
     if (fixedData.length === 0) return
 


### PR DESCRIPTION
Right now tentaclesql is requiring schema fields definition in order to
create the temporal tables. Since SQLite has dynamic typing this step is
not requiered. So in order to have simpler schemas and easier to
refactor I'm just infering column names from data received from the API
and leaving SQLite freedom to manage its own typing.

So from this changes TentacleSQL will create the tables based on the
data received by the actually sources requests.

More info:

https://www.sqlite.org/faq.html
https://www.sqlite.org/datatype3.html

Bonus track! If the data returned by source APIs are nested json Tentacle will automatically plain this data.

So `my.super.nested.structure` will be translated into `my_super_nested_structure` column name.

TODO:
- [ ] Check how this behavior could work when an API don't return data.