### PR TITLE
Passing ast as custom header to table fetches for optimizations

### DIFF
--- a/src/executor/index.spec.ts
+++ b/src/executor/index.spec.ts
@@ -61,8 +61,8 @@ test('executor', async () => {
 
   expect(mockedFetch).toHaveBeenCalledTimes(3)
   expect(mockedFetch).toHaveBeenCalledWith('https://api.example.com/schema', { headers })
-  expect(mockedFetch).toHaveBeenCalledWith('https://api.example.com/tables/goal_configs', { headers: {...headers, 'x-tentacle-query-ast': ast }})
-  expect(mockedFetch).toHaveBeenCalledWith('https://api.example.com/tables/employees', { headers: { ...headers, 'x-tentacle-query-ast': ast }})
+  expect(mockedFetch).toHaveBeenCalledWith('https://api.example.com/tables/goal_configs', { headers: {...headers, 'x-tentacle-query-ast': ast } })
+  expect(mockedFetch).toHaveBeenCalledWith('https://api.example.com/tables/employees', { headers: { ...headers, 'x-tentacle-query-ast': ast } })
   expect(result).toEqual([{ value: 25 }])
 })
 

--- a/src/executor/index.spec.ts
+++ b/src/executor/index.spec.ts
@@ -1,6 +1,7 @@
 import fetch from 'node-fetch'
 import executor from './index'
 import { version } from '../../package.json'
+import { parseSql } from './queryParser'
 
 jest.mock('node-fetch')
 
@@ -56,11 +57,12 @@ test('executor', async () => {
   const sql = 'SELECT employees.id + goal_configs.id as value FROM goal_configs JOIN employees ON (employees.id + ?) == goal_configs.id'
 
   const result = await executor(sql, [5], headers)
+  const ast = JSON.stringify(parseSql(sql))
 
   expect(mockedFetch).toHaveBeenCalledTimes(3)
   expect(mockedFetch).toHaveBeenCalledWith('https://api.example.com/schema', { headers })
-  expect(mockedFetch).toHaveBeenCalledWith('https://api.example.com/tables/goal_configs', { headers })
-  expect(mockedFetch).toHaveBeenCalledWith('https://api.example.com/tables/employees', { headers })
+  expect(mockedFetch).toHaveBeenCalledWith('https://api.example.com/tables/goal_configs', { headers: {...headers, 'x-tentacle-query-ast': ast }})
+  expect(mockedFetch).toHaveBeenCalledWith('https://api.example.com/tables/employees', { headers: { ...headers, 'x-tentacle-query-ast': ast }})
   expect(result).toEqual([{ value: 25 }])
 })
 

--- a/src/executor/index.spec.ts
+++ b/src/executor/index.spec.ts
@@ -61,7 +61,7 @@ test('executor', async () => {
 
   expect(mockedFetch).toHaveBeenCalledTimes(3)
   expect(mockedFetch).toHaveBeenCalledWith('https://api.example.com/schema', { headers })
-  expect(mockedFetch).toHaveBeenCalledWith('https://api.example.com/tables/goal_configs', { headers: {...headers, 'x-tentacle-query-ast': ast } })
+  expect(mockedFetch).toHaveBeenCalledWith('https://api.example.com/tables/goal_configs', { headers: { ...headers, 'x-tentacle-query-ast': ast } })
   expect(mockedFetch).toHaveBeenCalledWith('https://api.example.com/tables/employees', { headers: { ...headers, 'x-tentacle-query-ast': ast } })
   expect(result).toEqual([{ value: 25 }])
 })

--- a/src/executor/index.ts
+++ b/src/executor/index.ts
@@ -112,14 +112,14 @@ async function executor (
 
   const db = createDatabase(config.extensions)
 
-  const usedTables = extractTables(sql)
+  const ast = parseSql(sql)
+  const usedTables = extractTables(ast)
 
   if (usedTables.length > 0) {
     delete headers['content-length']
 
     const schema: Schema = await fetchSchema(headers, config.schema)
 
-    const ast = parseSql(sql)
     await populateTables(
       db,
       usedTables, {

--- a/src/executor/queryParser/index.spec.ts
+++ b/src/executor/queryParser/index.spec.ts
@@ -1,8 +1,9 @@
-import { extractTables } from './index'
+import { extractTables, parseSql } from './index'
 
 test('extractTables', () => {
   const subject = (sql: string) => {
-    return extractTables(sql)
+    const ast = parseSql(sql)
+    return extractTables(ast)
   }
 
   expect(subject('SELECT goal_config_id, name FROM goals_config WHERE goal_config_id > (SELECT COUNT(*) - 100 FROM employee) AND 1=1')).toEqual([

--- a/src/executor/queryParser/index.ts
+++ b/src/executor/queryParser/index.ts
@@ -15,12 +15,12 @@ function validateQuery (ast: any) {
   if (!['select', 'compound'].includes(ast.statement[0].variant)) throw new Error('Only SELECT queries are supported')
 }
 
-function parse (sql: string) {
+export function parseSql (sql: string) {
   return sqliteParser(sql)
 }
 
 export function extractTables (sql: string) {
-  const ast = parse(sql)
+  const ast = parseSql(sql)
 
   validateQuery(ast)
 

--- a/src/executor/queryParser/index.ts
+++ b/src/executor/queryParser/index.ts
@@ -19,9 +19,7 @@ export function parseSql (sql: string) {
   return sqliteParser(sql)
 }
 
-export function extractTables (sql: string) {
-  const ast = parseSql(sql)
-
+export function extractTables (ast: any) {
   validateQuery(ast)
 
   const tables: Array<string> = []


### PR DESCRIPTION
We're facing some performance problems while fetching full tables with
huge amounts of rows.
This PR changes how tentacle fetches the tables by passing them the
query ast to the endpoint so we could have a mechanism to optimize this
table generations.