### PR TITLE
feat(server): properly returning 400 HTTP code for syntax errors

### DIFF
--- a/src/server/index.spec.ts
+++ b/src/server/index.spec.ts
@@ -61,6 +61,22 @@ describe('server', () => {
       expect(response.statusCode).toBe(200)
     })
 
+    it('proper handles invalid SQL', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/',
+        body: {
+          query: 'SELECasdf',
+          config: {
+            extensions: [],
+            schema: []
+          }
+        }
+      })
+
+      expect(response.statusCode).toBe(422)
+    })
+
     it('accepts manual schema into the same request', async () => {
       const schemaBody = [
         {

--- a/src/server/index.spec.ts
+++ b/src/server/index.spec.ts
@@ -74,7 +74,7 @@ describe('server', () => {
         }
       })
 
-      expect(response.statusCode).toBe(422)
+      expect(response.statusCode).toBe(400)
     })
 
     it('accepts manual schema into the same request', async () => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,4 +1,4 @@
-import fastify from 'fastify'
+import fastify, { FastifyRequest, FastifyReply } from 'fastify'
 import executor from '../executor'
 import type { Extension } from '../executor'
 import logger from '../logger'
@@ -12,8 +12,18 @@ interface Body {
   }
 }
 
+
 const build = () => {
   const server = fastify({ logger: logger })
+  server.setErrorHandler(function (error: any, request: FastifyRequest, reply: FastifyReply) {
+    this.log.error(error)
+
+    if (error?.name === 'SyntaxError') {
+      reply.code(400)
+    }
+
+    reply.send(error)
+  })
 
   // SQL Query endpoint
   server.post<{ Body: Body }>('/', async (request, reply) => {
@@ -26,26 +36,16 @@ const build = () => {
         .send({ errors: 'Invalid SQL query' })
     }
 
-    try {
-      const result = await executor(
-        request.body.query,
-        request.body.parameters || [],
-        request.headers,
-        request.body.config
-      )
+    const result = await executor(
+      request.body.query,
+      request.body.parameters || [],
+      request.headers,
+      request.body.config
+    )
 
-      server.log.info(result)
+    server.log.info(result)
 
-      reply.send(result)
-    } catch (error: any) {
-      server.log.error(error)
-
-      if (error?.name === 'SyntaxError') {
-        return reply.code(422).send(error)
-      }
-
-      reply.send(error)
-    }
+    reply.send(result)
   })
 
   // Health check route

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -40,6 +40,10 @@ const build = () => {
     } catch (error) {
       server.log.error(error)
 
+      if (error?.name === 'SyntaxError') {
+        return reply.code(422).send(error)
+      }
+
       reply.send(error)
     }
   })

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -37,7 +37,7 @@ const build = () => {
       server.log.info(result)
 
       reply.send(result)
-    } catch (error) {
+    } catch (error: any) {
       server.log.error(error)
 
       if (error?.name === 'SyntaxError') {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -12,7 +12,6 @@ interface Body {
   }
 }
 
-
 const build = () => {
   const server = fastify({ logger: logger })
   server.setErrorHandler(function (error: any, request: FastifyRequest, reply: FastifyReply) {


### PR DESCRIPTION
Right now we're returning a generic 500 error for any error related to
tentaclesql. We're interested on discarding all the user facing errors
from this service consumers. So this PR fixes that by analysing the
error returned by executor and returning a unprocessable_entity error if
the privded SQL has a syntaxis error.