### PR TITLE
Experiencing bulk api

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,4 +154,6 @@ tentaclesql query "SELECT 1;"
 ```
 
 ### Bulk fetch
-`BULK_FETCH=true` and `BULK_FETCH_URL=url` to fetch all data in one HTTP request. #TODO: explain in details
+By default Tentacle sends one HTTP request for each table data, however you can change this and fetch all table data in one HTTP request. To enable this you need to pass following paramaters:
+- `BULK_FETCH=true`
+- `BULK_FETCH_URL=url`

--- a/README.md
+++ b/README.md
@@ -152,3 +152,6 @@ yarn cli query "SELECT 1;"
 # or installed global
 tentaclesql query "SELECT 1;"
 ```
+
+### Bulk fetch
+`BULK_FETCH=true` and `BULK_FETCH_URL=url` to fetch all data in one HTTP request. #TODO: explain in details

--- a/src/executor/index.ts
+++ b/src/executor/index.ts
@@ -75,6 +75,9 @@ async function fetchTablesData (
   queryAst: any,
   method: 'POST' | 'GET' = 'POST'
 ): Promise<any> {
+  if (process.env.BULK_FETCH_URL == undefined ) {
+    return Error(`Bulk fetch requested but bulk fetch url is not defined.`)
+  }
   const res = await fetch(
     process.env.BULK_FETCH_URL, {
       headers: headers,
@@ -123,7 +126,7 @@ async function populateTablesInOneHTTPRequest (
   ) => usedTables.includes(tableDefinition.name))
   const remoteData = await fetchTablesData(filteredTableDefinition, headers, queryAst)
   filteredTableDefinition.forEach((tableDefinition: TableDefinition) => {
-    const targetTable = remoteData.find(tableData => tableData.name === tableDefinition.name)
+    const targetTable = remoteData.find((tableData: any) => tableData.name === tableDefinition.name)
     syncData(
       tableDefinition,
       targetTable.data,

--- a/src/executor/index.ts
+++ b/src/executor/index.ts
@@ -75,8 +75,8 @@ async function fetchTablesData (
   queryAst: any,
   method: 'POST' | 'GET' = 'POST'
 ): Promise<any> {
-  if (process.env.BULK_FETCH_URL == undefined ) {
-    return Error(`Bulk fetch requested but bulk fetch url is not defined.`)
+  if (process.env.BULK_FETCH_URL === undefined) {
+    return Error('Bulk fetch requested but bulk fetch url is not defined.')
   }
   const res = await fetch(
     process.env.BULK_FETCH_URL, {


### PR DESCRIPTION
Tentacle sends one HTTP request for each table definition. It would create a high load on receiver. This PR introduces a bulk fetch mechanism, so for every query, it will send only one HTTP request for all used tables.