### PR TITLE
fix: make SqliteError fail nicely

### DIFF
--- a/src/server/index.spec.ts
+++ b/src/server/index.spec.ts
@@ -61,7 +61,7 @@ describe('server', () => {
       expect(response.statusCode).toBe(200)
     })
 
-    it('proper handles invalid SQL', async () => {
+    it('properly handles invalid SQL', async () => {
       const response = await app.inject({
         method: 'POST',
         url: '/',
@@ -75,6 +75,24 @@ describe('server', () => {
       })
 
       expect(response.statusCode).toBe(400)
+      expect(response.body).toBe('Syntax error found near WITH Clause (Statement)')
+    })
+
+    it('properly handles valid SQL that generates an error', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/',
+        body: {
+          query: 'SELECT foo WHERE bar;',
+          config: {
+            extensions: [],
+            schema: []
+          }
+        }
+      })
+
+      expect(response.statusCode).toBe(400)
+      expect(response.body).toBe('no such column: foo')
     })
 
     it('accepts manual schema into the same request', async () => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -12,13 +12,18 @@ interface Body {
   }
 }
 
+const FORWARDED_MESSAGES = ['SyntaxError', 'SqliteError']
+
 const build = () => {
   const server = fastify({ logger: logger })
+
   server.setErrorHandler(function (error: any, request: FastifyRequest, reply: FastifyReply) {
     this.log.error(error)
 
-    if (error?.name === 'SyntaxError') {
+    if (FORWARDED_MESSAGES.includes(error?.name)) {
       reply.code(400)
+      reply.send(error.message)
+      return
     }
 
     reply.send(error)


### PR DESCRIPTION
Our users can make mistakes. For instance, they may use a custom field
that is deleted, or mistype `employe`. Those are invalid queries, hence
it should return a 400 error and give back the information to them.

With the current implementation, we were only returning a 400 when we
failed to parse the SQL. But valid SQLs can be invalid queries.

This will mitigate hundreds of errors everyday and improve the user
experience.